### PR TITLE
chore: improved seat alert rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Edit `config.json` to configure theaters, scraping behavior, and intervals:
 | `server.output_retention_days` | `7` | Days to keep output JSON files |
 | `server.logs_retention_days` | `90` | Days to keep status logs |
 | `telegram.retention_days` | `30` | Days to keep notification history |
+| `server.seat_poll_delay_seconds` | `2.0` | Delay (jittered) between seat-map fetches to avoid AMC rate limits |
 
 ## Status Logs
 

--- a/amc_showtime_alert/seat_alerts/poller.py
+++ b/amc_showtime_alert/seat_alerts/poller.py
@@ -13,16 +13,18 @@ unreachable showing is simply retried next cycle.
 """
 
 import logging
+import random
 import time
 from typing import Callable, Dict, List, Optional
 
 from .manager import SeatAlert, SeatAlertManager
-from .seat_map import SeatLayout, fetch_seat_layout, good_available_seats
+from .seat_map import RateLimited, SeatLayout, fetch_seat_layout, good_available_seats
 
 logger = logging.getLogger("SeatAlertPoller")
 
-# Seconds between seat-map fetches, to stay under AMC's rate limit.
-FETCH_DELAY_SECONDS = 1.5
+# Base seconds between seat-map fetches, to stay under AMC's rate limit. The
+# actual gap is jittered up to +50% so we don't hammer on a fixed cadence.
+FETCH_DELAY_SECONDS = 2.0
 
 # Cap how many seat names we list in one message.
 MAX_SEATS_SHOWN = 10
@@ -74,18 +76,27 @@ def poll_seat_alerts(
     given, fires are delivered as a rendered seat-map image with the text as the
     caption (falling back to text on any render error). `fetch(showtime_id)` is
     injectable for testing.
+
+    Fetches are spaced by `delay` seconds (jittered) to stay under AMC's rate
+    limit; if AMC starts throttling (429 / virtual queue) the cycle stops early
+    rather than hammering, and resumes next cycle.
     """
     fetch = fetch or fetch_seat_layout
     mgr = SeatAlertManager(db_path)
     alerts = mgr.get_pollable()
-    stats = {"checked": 0, "notified": 0, "unreachable": 0}
+    stats = {"checked": 0, "notified": 0, "unreachable": 0, "rate_limited": 0}
 
     for i, alert in enumerate(alerts):
-        layout = fetch(alert.showtime_id)
+        try:
+            layout = fetch(alert.showtime_id)
+        except RateLimited as e:
+            logger.warning(f"Rate limited by AMC — stopping seat poll early ({e})")
+            stats["rate_limited"] = 1
+            break
         stats["checked"] += 1
         if layout is None:
             stats["unreachable"] += 1
-            continue  # transient (queue/429/format change) — retry next cycle
+            continue  # transient (sold out / format change) — retry next cycle
 
         good_names = sorted(s["name"] for s in good_available_seats(layout))
         previously = set(alert.last_good_seats)
@@ -98,6 +109,6 @@ def poll_seat_alerts(
         mgr.update_last_good_seats(alert.id, good_names)
 
         if delay and i < len(alerts) - 1:
-            sleep(delay)
+            sleep(delay * random.uniform(1.0, 1.5))  # jittered spacing
 
     return stats

--- a/amc_showtime_alert/seat_alerts/seat_map.py
+++ b/amc_showtime_alert/seat_alerts/seat_map.py
@@ -33,6 +33,12 @@ except ImportError:
 
 logger = logging.getLogger("SeatMap")
 
+
+class RateLimited(Exception):
+    """AMC is throttling us — a 429 or the virtual-queue page. The poller should
+    stop fetching for this cycle rather than hammer the endpoint further."""
+
+
 AMC_BASE_URL = "https://www.amctheatres.com"
 # The ?_rsc=<value> query param is what makes AMC's edge serve the React Server
 # Component payload directly instead of redirecting to the virtual queue. Only
@@ -105,6 +111,8 @@ def fetch_seat_layout(showtime_id: str, timeout: int = 30) -> Optional[SeatLayou
         logger.warning(f"Seat fetch for {showtime_id} failed: {e}")
         return None
 
+    if response.status_code == 429:
+        raise RateLimited(f"429 Too Many Requests for {showtime_id}")
     if not response.ok:
         logger.warning(f"Seat fetch for {showtime_id} returned {response.status_code}")
         return None
@@ -113,16 +121,14 @@ def fetch_seat_layout(showtime_id: str, timeout: int = 30) -> Optional[SeatLayou
     if layout is None:
         # A 2xx with no seatingLayout. The common, EXPECTED case is a fully
         # sold-out showtime (AMC shows a "sold out" notice instead of the map) —
-        # that's normal for a watched show, so it's debug, not a warning. A
-        # virtual-queue/anti-bot page or anything else is genuinely noteworthy.
+        # that's normal for a watched show, so it's debug, not a warning. The
+        # virtual-queue page means we're being throttled → signal the poller.
         text = response.text
         low = text.lower()
         if "showtime is sold out" in low or "sold out, please choose" in low:
             logger.debug(f"Seat map for {showtime_id}: sold out — no seats to show yet")
         elif "queue.amctheatres" in text or "/queue" in text:
-            logger.warning(
-                f"Seat map for {showtime_id} unavailable — virtual queue (rate-limited?)"
-            )
+            raise RateLimited(f"virtual-queue page for {showtime_id}")
         else:
             logger.warning(
                 f"Seat map for {showtime_id} unavailable — "

--- a/config.json
+++ b/config.json
@@ -44,6 +44,7 @@
   "server": {
     "interval_minutes": 20,
     "output_retention_days": 7,
-    "logs_retention_days": 90
+    "logs_retention_days": 90,
+    "seat_poll_delay_seconds": 2.0
   }
 }

--- a/run_alert_pipeline.py
+++ b/run_alert_pipeline.py
@@ -41,7 +41,7 @@ from amc_showtime_alert.user_manager import UserManager
 from amc_showtime_alert.alert_manager import AlertManager
 from amc_showtime_alert.alert_matcher import find_alert_matches
 from amc_showtime_alert.seat_alerts.manager import SeatAlertManager
-from amc_showtime_alert.seat_alerts.poller import poll_seat_alerts
+from amc_showtime_alert.seat_alerts.poller import poll_seat_alerts, FETCH_DELAY_SECONDS
 from amc_showtime_alert.telegram.api import TelegramAPI
 from amc_showtime_alert.schema import EventData, EventType
 
@@ -511,16 +511,21 @@ class AlertPipeline:
                 return empty
 
             api = TelegramAPI(bot_token)
+            delay = self.config.get("server", {}).get(
+                "seat_poll_delay_seconds", FETCH_DELAY_SECONDS
+            )
             stats = poll_seat_alerts(
                 self.db_path,
                 send=lambda chat_id, text: api.send_message(chat_id, text),
                 send_photo=lambda chat_id, png, caption: api.send_photo(
                     chat_id, png, caption
                 ),
+                delay=delay,
             )
             self.logger.info(
                 f"🎟 Seat alerts: checked={stats['checked']} "
-                f"notified={stats['notified']} unreachable={stats['unreachable']}"
+                f"notified={stats['notified']} unreachable={stats['unreachable']} "
+                f"rate_limited={stats.get('rate_limited', 0)}"
             )
             return stats
         except Exception as e:

--- a/test/test_seat_alerts.py
+++ b/test/test_seat_alerts.py
@@ -155,6 +155,23 @@ class TestSeatPoller(unittest.TestCase):
         self.assertIn("G5", photos[0][2])                     # caption text
         self.assertEqual(self.sent, [])                       # text path not used
 
+    def test_rate_limited_stops_cycle_early(self):
+        from amc_showtime_alert.seat_alerts.seat_map import RateLimited
+        # Add a second alert so there are two to poll.
+        self.mgr.create(CHAT, "222", TOMORROW, movie_name="Wicked")
+        calls = []
+
+        def fetch(sid):
+            calls.append(sid)
+            raise RateLimited("429")
+
+        stats = poll_seat_alerts(
+            self.db, send=lambda *a: True, fetch=fetch,
+            sleep=lambda *_: None, delay=0,
+        )
+        self.assertEqual(stats["rate_limited"], 1)
+        self.assertEqual(len(calls), 1)  # stopped after the first 429, didn't hammer
+
     def test_unreachable_layout_skipped(self):
         stats = poll_seat_alerts(
             self.db,
@@ -162,7 +179,9 @@ class TestSeatPoller(unittest.TestCase):
             fetch=lambda sid: None,  # transient failure
             sleep=lambda *_: None, delay=0,
         )
-        self.assertEqual(stats, {"checked": 1, "notified": 0, "unreachable": 1})
+        self.assertEqual(
+            stats, {"checked": 1, "notified": 0, "unreachable": 1, "rate_limited": 0}
+        )
         self.assertEqual(self.sent, [])
 
 


### PR DESCRIPTION
## Harden seat-alert polling against AMC rate limits

Improves how the seat poller handles non-seat responses from AMC's
seat-selection endpoint, so a backlog of watched showings doesn't trip
rate limiting or spam the logs.

### Changes
- **Classify 2xx-without-seatmap responses** instead of logging a blanket
  warning:
  - **Sold out** ("this showtime is sold out…") → `DEBUG`. This is the
    *expected* state for a watched show, so it's no longer noisy.
  - **429 / virtual-queue page** → raise `RateLimited`.
  - **Anything else** → `WARNING` (now includes the showtime id + byte count).
- **Back off when throttled:** the poller stops the cycle early on
  `RateLimited` rather than continuing to hammer; resumes next interval.
- **Gentler pacing:** inter-fetch delay bumped to 2s, **jittered** (+0–50%),
  and made configurable via `server.seat_poll_delay_seconds` in `config.json`.

### Notes
- A 100%-sold-out show renders no seat map, so the first freed seat is caught
  on the next poll after it appears (inherent to AMC's page).
- Tests: added a rate-limit-aborts-cycle test; full suite green.